### PR TITLE
refac: remove conditional rendering in Form

### DIFF
--- a/src/Components/Form/Form.js
+++ b/src/Components/Form/Form.js
@@ -1,31 +1,19 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import './Form.css'
 
 const Form =  () => {
   const [searchQuery, setSearchQuery] = useState('')
-  const [searched, setSearched] = useState(false)
-
-  const search = () => {
-    setSearched(true)
-  }
 
   const reset = () => {
-    setSearched(false)
     setSearchQuery('')
   }
 
-  const showingMsg = <h3>{`Showing results for '${searchQuery}'`}<Link to={`/`}><button onClick={reset}>Reset</button></Link></h3>
-
-  const searchField = <div>
-    <input type="search" value={searchQuery} onInput={(event) => setSearchQuery(event.target.value)}></input>
-    <Link to={`/search/${searchQuery}`}><button onClick={search}>Search All Books</button></Link>
-  </div>
-
   return (
     <form>
-      {!searched && searchField}
-      {searched && showingMsg}
+      <input type="search" value={searchQuery} onInput={(event) => setSearchQuery(event.target.value)}></input>
+      <Link to={`/search/${searchQuery}`}><button>Search All Books</button></Link>
+      <Link to={`/`}><button onClick={reset}>Reset</button></Link>
     </form>
   )
 }


### PR DESCRIPTION
## Files Changed:

- Form.js

## Changes Made:

- My goal was to conditionally render the search input field and a h3 stating 'showing results for 'searchQuery'', but there was a bug and I was having a hard time preserving the controlled form state when the user went back with the browser nav arrows. I may come back to this, but for now I left the reset and search button along with the search field on the page no matter what so I can continue moving forward with styling/book info page data.
