### PR TITLE
refac: break up cleanData function into multiple single responsibility functions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,12 +6,11 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans&family=Righteous&display=swap" rel="stylesheet">
-
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Let's Read!"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -33,7 +33,6 @@ const App = () => {
 
   const showSearchResults = (match) => {
     const filteredBooks = allBooks.filter(book => book.title.includes(match.params.searchQuery) || book.title.includes(match.params.searchQuery.toUpperCase()));
-
     return (
       <div>
         <Form />
@@ -43,7 +42,6 @@ const App = () => {
 
   const showBookInfo = (match) => {
     const selectedBook = allBooks.find(book => book.primary_isbn10 === match.params.id)
-
     return (
       <BookInfo selectedBook={selectedBook}/>
     )}

--- a/src/Utilities/ApiCalls.js
+++ b/src/Utilities/ApiCalls.js
@@ -1,14 +1,7 @@
 const fetchApi = async (url) => {
     const response = await fetch(url)
     const fullOverview = await response.json();
-    const books = await fullOverview.results.lists.reduce((accumulator, currentlist) => {
-      currentlist.books.forEach(book => {
-        book.genre = currentlist.list_name;
-        accumulator.push(book);
-      })
-      return accumulator;
-    }, [])
-    return books;
+    return fullOverview;
 }
 
 export { fetchApi }

--- a/src/Utilities/dataCleaning.js
+++ b/src/Utilities/dataCleaning.js
@@ -1,17 +1,34 @@
-const cleanData = (bookData) => {
-  bookData.forEach(book => {
+const pullBooksFromOverview = (data) => {
+  return data.results.lists.reduce((accumulator, currentlist) => {
+    currentlist.books.forEach(book => {
+      book.genre = currentlist.list_name;
+      accumulator.push(book);
+    })
+    return accumulator;
+  }, [])
+}
+
+const assignISBN = (data) => {
+  data.forEach(book => {
     if(book.primary_isbn10 === '' || 'none') {
       book.primary_isbn10 = book.primary_isbn13;
     }
   })
+}
 
-  const uniqueBooks = bookData.reduce((accumulator, currentBook) => {
+const removeRepeats = (data) => {
+  return data.reduce((accumulator, currentBook) => {
     if (!accumulator.find((book) => book.title === currentBook.title)) {
       accumulator.push(currentBook);
     }
     return accumulator;
   }, []);
-  return uniqueBooks;
+}
+
+const cleanData = (data) => {
+  const books = pullBooksFromOverview(data)
+  assignISBN(books)
+  return removeRepeats(books)
 }
 
 export default cleanData;


### PR DESCRIPTION
## Changes Made:

- Remove logic from API call file that pulls out nested book objects and put it into data cleaning file
- Broke up cleanData function into 3 separate functions: pullBooksFromOverview, assignISBN, and removeRepeats
- Create a fourth function called cleanData that invokes all 3 of these functions to properly clean API data
- cleanData is then invoked when the fetch request is completed and the properly cleaned API data is stored to App state